### PR TITLE
Add prefix to glossary term element ids

### DIFF
--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -34,8 +34,11 @@ export function renderGlossary(
   definitions: Definition[],
   linkableTerms: LinkableTerms
 ) {
-  const renderedDefs = definitions.map(def =>
-    renderKnowledgeItem(def, linkableTerms)
+  const renderedDefs = definitions.map(def => {
+      let item = renderKnowledgeItem(def, linkableTerms)
+      item.key = `glossary-${item.key}`
+      return item
+    }
   )
   // sort the array alphabetically by term
   renderedDefs.sort((a, b) => a.titleforSort.localeCompare(b.titleforSort))


### PR DESCRIPTION
There's a significant risk of the glossary id's being non-unique if embedded into other pages with section titles. In order to guarantee uniqueness, add the prefix 'glossary' to all elements.

The only downside of this approach is that the anchors to items on the glossary page will look a little messier, but I think that's probably ok