### PR TITLE
Enforce node version >16

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "private": false,
   "engines" : { 
-    "node" : ">=15.0.0"
+    "node" : ">=16.0.0"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Node v <=14 doesn't have String.replaceAll