### PR TITLE
updates spacing of tags to fix build for mdx update

### DIFF
--- a/src/format/block.ts
+++ b/src/format/block.ts
@@ -51,7 +51,7 @@ export function renderBlock(
     switch (blockResponse.type) {
       case 'paragraph': {
         const text = renderRich(blockResponse.paragraph.rich_text)
-        return `<p>${text}</p>\n`
+        return `<p>\n${text}\n</p>\n`
       }
       case 'numbered_list_item': {
         const text = renderRich(blockResponse.numbered_list_item.rich_text)

--- a/src/format/text.ts
+++ b/src/format/text.ts
@@ -69,7 +69,7 @@ function renderRichText(
         }
       }
       if (renderMode == RenderMode.HTML) {
-        text = text.replaceAll('\n', '\n<br />')
+        text = text.replaceAll('\n', '\n<br />\n')
       }
       return text
     }

--- a/src/item.ts
+++ b/src/item.ts
@@ -47,11 +47,11 @@ export function renderKnowledgeItem(
 
     let renderedText = renderBlocks(item.blocks, linkableTerms)
     if (renderedText.length == 0) {
-      renderedText = `<p>${renderRichTexts(
+      renderedText = `<p>\n${renderRichTexts(
         item.text,
         linkableTerms,
         RenderMode.HTML
-      )}</p>`
+      )}\n</p>`
     }
     return {
       title: title,


### PR DESCRIPTION
adds new lines before and/or after `<ul>`, `<ol>`, `<br />`, and `<p>` tags.

This change is being made because an update to MDX fails to parse HTML in markdown when a line that starts with a particular tag does not end that paragraph with the proper closing tag for the element. 

This update modifies the html file output, but does not change the rendered output in the user's browser.