### PR TITLE
Fix markdown rendering bugs from Notion export

### DIFF
--- a/src/format/block.ts
+++ b/src/format/block.ts
@@ -6,6 +6,19 @@ import type { RichTextItemResponse } from '@notionhq/client/build/src/api-endpoi
 import type { Block } from '../notion'
 import type { LinkableTerms } from './link'
 
+// Notion uses human-readable language names that may not match Prism/Docusaurus identifiers
+const LANGUAGE_MAP: Record<string, string> = {
+  'plain text': 'text',
+  'c++': 'cpp',
+  'c#': 'csharp',
+  'objective-c': 'objectivec',
+  'visual basic': 'vb',
+}
+
+function normalizeCodeLanguage(language: string): string {
+  return LANGUAGE_MAP[language] ?? language
+}
+
 export function renderBlock(
   block: Block,
   linkableTerms: LinkableTerms,
@@ -82,12 +95,13 @@ export function renderBlock(
       }
       case 'code': {
         const text = renderRichWithMode(blockResponse.code.rich_text, RenderMode.Plain)
+        const lang = normalizeCodeLanguage(blockResponse.code.language)
         if (renderMode === RenderMode.Markdown) {
-          return `\`\`\`${blockResponse.code.language}\n${text}\n\`\`\`\n`
+          return `\`\`\`${lang}\n${text}\n\`\`\`\n`
         } else if (renderMode === RenderMode.Plain) {
           return `${text}\n`
         }
-        return `<pre><code class="language-${blockResponse.code.language}">${text}</code></pre>\n`
+        return `<pre><code class="language-${lang}">${text}</code></pre>\n`
       }
       case 'divider': {
         if (renderMode === RenderMode.Markdown) {

--- a/src/format/link.ts
+++ b/src/format/link.ts
@@ -37,17 +37,32 @@ export class MissingPageError extends Error {
   }
 }
 
+// Notion internal URLs use notion.so with doc-like paths.
+// Convert them to relative paths for the docs site.
+function rewriteNotionUrl(url: string): string {
+  const notionPrefix = 'https://www.notion.so/'
+  if (url.startsWith(notionPrefix)) {
+    let path = url.slice(notionPrefix.length)
+    // Strip .mdx/.md extension — Docusaurus routes don't use them
+    path = path.replace(/\.mdx?$/, '')
+    console.warn(`Rewriting Notion URL to relative path: ${url} -> /${path}`)
+    return `/${path}`
+  }
+  return url
+}
+
 export function renderLink(
   text: string,
   url: string,
   anchor: string,
   renderMode: RenderMode
 ): string {
+  const resolvedUrl = rewriteNotionUrl(url)
   switch (renderMode) {
     case RenderMode.HTML:
-      return `<a href="${url}${anchor}">${text}</a>`
+      return `<a href="${resolvedUrl}${anchor}">${text}</a>`
     case RenderMode.Markdown:
-      return `[${text}](${url}${anchor})`
+      return `[${text}](${resolvedUrl}${anchor})`
     case RenderMode.Plain:
       return text
   }

--- a/src/format/text.ts
+++ b/src/format/text.ts
@@ -26,9 +26,8 @@ function renderRichText(
   switch (res.type) {
     case 'text': {
       let text = stripCurlyQuotes(res.text.content)
-      if (res.text.link) {
-        text = renderLink(text, res.text.link.url, '', renderMode)
-      }
+      // Apply inline annotations before link wrapping so that in markdown
+      // the link is outermost: [`code`](url) instead of `[code](url)`
       if (res.annotations.code) {
         switch (renderMode) {
           case RenderMode.HTML:
@@ -56,7 +55,6 @@ function renderRichText(
           case RenderMode.Plain:
             break
         }
-        
       }
       if (res.annotations.italic) {
         switch (renderMode) {
@@ -69,6 +67,9 @@ function renderRichText(
           case RenderMode.Plain:
             break
         }
+      }
+      if (res.text.link) {
+        text = renderLink(text, res.text.link.url, '', renderMode)
       }
       if (renderMode == RenderMode.HTML) {
         text = text.replaceAll('\n', '\n<br />\n')


### PR DESCRIPTION
## Summary

Fixes three rendering bugs in the Notion → Markdown conversion that cause garbled output on the production docs site (e.g. [troubleshooting-building-arbitrum-chain](https://docs.arbitrum.io/launch-arbitrum-chain/faq-troubleshooting/troubleshooting-building-arbitrum-chain)).

### 1. Code + Link annotation ordering (`text.ts`)

When a Notion span has both `annotations.code=true` and `text.link`, the renderer was applying the link first, then wrapping in backticks:

```
Before: `[MaxCodeSize](https://github.com/...)` → renders as literal code text
After:  [`MaxCodeSize`](https://github.com/...) → renders as a clickable code link
```

Fix: Apply inline annotations (code, bold, italic) before the link wrapper so the link is always outermost.

### 2. Notion internal URL rewriting (`link.ts`)

Notion pages that link to other Notion pages using internal path-like URLs (`https://www.notion.so/launch-arbitrum-chain/...`) were passed through as-is, creating dead links on the docs site.

Fix: Detect `notion.so` URLs, strip the prefix and `.mdx`/`.md` extension, and convert to relative paths. Emits a `console.warn` for visibility.

### 3. Code block language normalization (`block.ts`)

Notion's API uses human-readable language names like `"plain text"` that aren't valid Prism/Docusaurus identifiers, producing malformed code fences (` ```plain text `).

Fix: Add a `LANGUAGE_MAP` lookup table that normalizes known mismatches (`plain text` → `text`, `c++` → `cpp`, etc.).

## Affected output files in arbitrum-docs

- `docs/partials/_troubleshooting-arbitrum-chain-partial.mdx` (lines 56, 109, 123, 195, 197, 207, 211)
- `docs/partials/_troubleshooting-building-partial.mdx` (lines 89, 91, 196)

## Test plan

- [x] `yarn build` passes (TypeScript compilation)
- [x] Smoke tests for all three fixes (code+link ordering, Notion URL rewriting, language normalization)
- [ ] Re-run `yarn notion-update` in arbitrum-docs after bumping this package to verify output

🤖 Generated with [Claude Code](https://claude.com/claude-code)