### PR TITLE
Bump version to 0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@offchainlabs/notion-docs-generator",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "main": "bin/index.js",
   "types": "bin/index.d.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

Version bump to 0.1.2 following the markdown rendering fixes merged in #13.

## Changes

- `package.json`: version `0.1.1` → `0.1.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)